### PR TITLE
Improve stub-making scripts

### DIFF
--- a/scripts/build-stubs.sh
+++ b/scripts/build-stubs.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 
-git clone --depth 1 --branch main https://github.com/adafruit/circuitpython.git
-cd circuitpython
-git submodule init
-git submodule update extmod/ulab
-pip3 install -r docs/requirements.txt
-make stubs
-mv circuitpython-stubs ../stubs
-cd ..
-pip3 install -r requirements.txt
-python3 ./scripts/build_stubs.py
-rm -rf stubs/board
+(
+    # Current dir should be the root of the repo
+    cd $(dirname $0)/..
+
+    git clone --depth 1 --branch main https://github.com/adafruit/circuitpython.git
+
+    cd circuitpython
+    git submodule init
+    git submodule update extmod/ulab
+
+    # Use a venv for these
+    # Using this name so circuitpython repo already gitignores it
+    python3 -m venv .venv/
+    . .venv/bin/activate
+
+    # `make stubs` in circuitpython
+    pip3 install wheel  # required on debian buster for some reason
+    pip3 install -r docs/requirements.txt
+    make stubs
+    if [ -d ../stubs ]; then
+        mv circuitpython-stubs/* ../stubs/
+    else
+        # if stubs already exists, this would get interpreted as "move circuitpython-stubs *into* stubs"
+        # hence the "if".  Friendlier than the alternative, `rm -rf stubs`
+        mv circuitpython-stubs/ ../stubs
+    fi
+    cd ..
+
+    # scripts/build_stubs.py in this repo for board stubs
+    pip3 install -r requirements.txt
+    python3 ./scripts/build_stubs.py
+    rm -rf stubs/board
+
+    # get out of venv
+    deactivate
+)

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -53,7 +53,7 @@ def parse_pins(generic_stubs, pins, board_stubs):
       if pin_name in generic_stubs:
         board_stubs[pin_name] = generic_stubs[pin_name]
         if "busio" in generic_stubs[pin_name]:
-          imports.add("import busio\n")
+          imports.add("busio")
         continue
 
       pin_type = "Any"
@@ -63,14 +63,14 @@ def parse_pins(generic_stubs, pins, board_stubs):
       if advanced_pin is not None:
         pin_value = advanced_pin[2]
         if pin_value.startswith("&displays"):
-          imports.add("import displayio\n")
+          imports.add("displayio")
           pin_type = "displayio.Display"
       
       stub_lines.append("{0}: {1} = ...\n".format(pin_name, pin_type))
 
-  imports_string = "".join(sorted(imports))
+  imports_string = "".join("import %s\n" % x for x in sorted(imports))
 
-  # Indent 0 char for the first pin, 2 for the rest
+  # Indent 0 char for the first pin, 2 for the rest?
   stubs_string = "  ".join(stub_lines)
   return imports_string, stubs_string
 

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -11,10 +11,11 @@ import json
 # These need to be bundled with the extension, which means that adding new boards is still
 # a new release of the extension.
 
+repo_root = pathlib.Path(__file__).resolve().parent.parent
 # First thing we want to do is store in memory, the contents of 
-# ./circuitpython/circuitpython-stubs/board/__init__.py so we can append it to
+# ./stubs/board/__init__.py so we can append it to
 # every other board.
-board_stub = pathlib.Path(os.path.join("./stubs/board", "__init__.pyi"))
+board_stub = repo_root / "stubs" / "board" / "__init__.pyi"
 
 # See [Issue #26](https://github.com/joedevivo/vscode-circuitpython/issues/26) 
 # for more on this.
@@ -43,14 +44,15 @@ def normalize_vid_pid(vid_or_pid: str):
 
 # now, while we build the actual board stubs, replace any line that starts with `  $name:` with value
 
-board_dirs = glob.glob("circuitpython/ports/*/boards/*")
+board_dirs = repo_root.glob("circuitpython/ports/*/boards/*")
 boards = []
-for b in board_dirs :
-  site_path = os.path.split(b)[-1]
 
-  config = pathlib.Path(os.path.join(b, "mpconfigboard.mk"))
+for b in board_dirs:
+  site_path = b.stem
+
+  config = b / "mpconfigboard.mk"
   print(config)
-  pins   = pathlib.Path(os.path.join(b, "pins.c"))
+  pins   = b / "pins.c"
   if config.is_file() and pins.is_file():
 
     usb_vid = ""
@@ -89,9 +91,9 @@ for b in board_dirs :
              'description': description}
     boards.append(board)
     print("{0}:{1} {2}, {3}".format(usb_vid, usb_pid, usb_manufacturer, usb_product))
-    board_pyi_path = pathlib.Path(os.path.join("boards", usb_vid, usb_pid))
+    board_pyi_path = repo_root / "boards" / usb_vid / usb_pid
     board_pyi_path.mkdir(parents=True, exist_ok=True)
-    board_pyi_file = pathlib.Path(os.path.join(board_pyi_path, "board.pyi"))
+    board_pyi_file = board_pyi_path / "board.pyi"
 
     # Indent 0 char for the first pin, 2 for the rest
     indent = ""
@@ -122,7 +124,7 @@ for b in board_dirs :
       # End for
       for p in board_stubs:
         outfile.write("{0}\n".format(board_stubs[p]))
-    
-json_file = pathlib.Path(os.path.join("boards", "metadata.json"))
+
+json_file = repo_root / "boards" / "metadata.json"
 with open(json_file, 'w') as metadata:
   json.dump(boards, metadata)

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -37,6 +37,10 @@ with open(board_stub) as stub:
     generic_stubs[k] = it
     x = y
 
+def normalize_vid_pid(vid_or_pid: str):
+  """Make a hex string all uppercase except for the 0x."""
+  return vid_or_pid.upper().replace("0X", "0x")
+
 # now, while we build the actual board stubs, replace any line that starts with `  $name:` with value
 
 board_dirs = glob.glob("circuitpython/ports/*/boards/*")
@@ -66,7 +70,9 @@ for b in board_dirs :
     if usb_manufacturer == "Nadda-Reel Company LLC":
       continue
 
-    board = { 'vid': usb_vid, 'pid': usb_pid, 'product': usb_product, 'manufacturer': usb_manufacturer, 'site_path': site_path }
+    usb_vid = normalize_vid_pid(usb_vid)
+    usb_pid = normalize_vid_pid(usb_pid)
+
     boards.append(board)
     print("{0}:{1} {2}, {3}".format(usb_vid, usb_pid, usb_manufacturer, usb_product))
     board_pyi_path = pathlib.Path(os.path.join("boards", usb_vid, usb_pid))

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -67,12 +67,26 @@ for b in board_dirs :
           usb_product = line.split("=")[1].split("#")[0].strip('" \n')
         elif line.startswith("USB_MANUFACTURER"):
           usb_manufacturer = line.split("=")[1].split("#")[0].strip('" \n')
+        
+        # CircuitPython 7 BLE-only boards
+        elif line.startswith("CIRCUITPY_CREATOR_ID"):
+          usb_vid = line.split("=")[1].split("#")[0].strip('" \n')
+        elif line.startswith("CIRCUITPY_CREATION_ID"):
+          usb_pid = line.split("=")[1].split("#")[0].strip('" \n')
     if usb_manufacturer == "Nadda-Reel Company LLC":
       continue
 
     usb_vid = normalize_vid_pid(usb_vid)
     usb_pid = normalize_vid_pid(usb_pid)
 
+    # CircuitPython 7 BLE-only boards have no usb manuf/product
+    description = site_path
+    if usb_manufacturer and usb_product:
+      description = '{0} {1}'.format(usb_manufacturer, usb_product)
+
+    board = {'vid': usb_vid, 'pid': usb_pid, 'product': usb_product,
+             'manufacturer': usb_manufacturer, 'site_path': site_path,
+             'description': description}
     boards.append(board)
     print("{0}:{1} {2}, {3}".format(usb_vid, usb_pid, usb_manufacturer, usb_product))
     board_pyi_path = pathlib.Path(os.path.join("boards", usb_vid, usb_pid))
@@ -89,7 +103,7 @@ for b in board_dirs :
     with open(board_pyi_file, 'w') as outfile, open(pins) as p:
       outfile.write("from typing import Any\n")
       outfile.write('"""\n')
-      outfile.write('board {0} {1}\n'.format(board['manufacturer'], board['product']))
+      outfile.write('board {0}\n'.format(board['description']))
       outfile.write('https://circuitpython.org/boards/{0}\n'.format(board['site_path']))
       outfile.write('"""\n')
       outfile.write("  board.")

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -59,6 +59,15 @@ def parse_pins(generic_stubs, pins, board_stubs):
         continue
 
       pin_type = "Any"
+
+      # sometimes we can guess better based on the value
+      advanced_pin = re.search(r'.*_QSTR\(MP_QSTR_([^\)]*)\)\s*,\s*MP_ROM_PTR\(([^\)]*)\)', line)
+      if advanced_pin is not None:
+        pin_value = advanced_pin[2]
+        if pin_value.startswith("&displays"):
+          imports.add("import displayio\n")
+          pin_type = "displayio.Display"
+      
       stub_lines.append("{0}: {1} = ...\n".format(pin_name, pin_type))
 
   imports_string = "".join(sorted(imports))

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -1,23 +1,21 @@
-import appdirs
-import subprocess
-import os
-#import mypy
-import pathlib
-import re
-import glob
-import json
-
+#!/usr/bin/env python3
 # This is a script for using circuitpython's repo to make pyi files for each board type.
 # These need to be bundled with the extension, which means that adding new boards is still
 # a new release of the extension.
 
+#import mypy
+import json
+import pathlib
+import re
+
+
 repo_root = pathlib.Path(__file__).resolve().parent.parent
-# First thing we want to do is store in memory, the contents of 
+# First thing we want to do is store in memory, the contents of
 # ./stubs/board/__init__.py so we can append it to
 # every other board.
 board_stub = repo_root / "stubs" / "board" / "__init__.pyi"
 
-# See [Issue #26](https://github.com/joedevivo/vscode-circuitpython/issues/26) 
+# See [Issue #26](https://github.com/joedevivo/vscode-circuitpython/issues/26)
 # for more on this.
 generic_stubs = {}
 with open(board_stub) as stub:
@@ -103,7 +101,7 @@ for b in board_dirs:
           usb_product = line.split("=")[1].split("#")[0].strip('" \n')
         elif line.startswith("USB_MANUFACTURER"):
           usb_manufacturer = line.split("=")[1].split("#")[0].strip('" \n')
-        
+
         # CircuitPython 7 BLE-only boards
         elif line.startswith("CIRCUITPY_CREATOR_ID"):
           usb_vid = line.split("=")[1].split("#")[0].strip('" \n')
@@ -129,7 +127,7 @@ for b in board_dirs:
     board_pyi_path.mkdir(parents=True, exist_ok=True)
     board_pyi_file = board_pyi_path / "board.pyi"
 
-    # We're going to put the common stuff from the generic board stub at the 
+    # We're going to put the common stuff from the generic board stub at the
     # end of the file, so we'll collect them after the loop
     board_stubs = {}
 

--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -103,6 +103,7 @@ for b in board_dirs:
     board_stubs = {}
 
     with open(board_pyi_file, 'w') as outfile, open(pins) as p:
+      outfile.write("from __future__ import annotations\n")
       outfile.write("from typing import Any\n")
       outfile.write('"""\n')
       outfile.write('board {0}\n'.format(board['description']))


### PR DESCRIPTION
I started by just improving the build-stubs.sh so it used a venv so I could actually run it locally, but then I saw a few other things on the way to what I was actually trying to do (get `board.DISPLAY` to be usefully typed, not just "Any"). I can probably do more for this but I'll leave well-enough alone for now, this is already a reasonable improvement.

This also fixes (somewhat) support for the MicroBit v2: it's a "BLE-Only" board so the assumptions that everybody had a usb vid/pid were not working out as well.

cc @tannewt because this improves stubs (and because I read #2 ), and this script probably belongs upstream in circuitpython itself.

PS. Why do the board stubs start with e.g. `  board.A0`? I can't get `black --pyi` to format them like this.