### PR TITLE
Detect displays that should be EPaperDisplay rather than regular displayio.Display

### DIFF
--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -78,7 +78,10 @@ def parse_pins(generic_stubs, pins: pathlib.Path, board_stubs):
 
             # sometimes we can guess better based on the value
             pin_value = pin.group("value")
-            if pin_value.startswith("&displays"):
+            if pin_value == "&displays[0].epaper_display":
+                imports.add("displayio")
+                pin_type = "displayio.EPaperDisplay"
+            elif pin_value == "&displays[0].display":
                 imports.add("displayio")
                 pin_type = "displayio.Display"
             elif pin_value.startswith("&pin_"):


### PR DESCRIPTION
Realized we were missing this detail when doing some magtag coding.