### PR TITLE
Only update desired key in `python.analysis.diagnosticSeverityOverrides`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.getConfiguration().update("python.languageServer", "Pylance");
 	vscode.workspace.getConfiguration().update("python.linting.pylintEnabled", false);
 
-	let config_key = "python.analysis.diagnosticSeverityOverrides"
-	let config_value = vscode.workspace.getConfiguration()[config_key];
-	config_value["reportMissingModuleSource"] = "none";
-	vscode.workspace.getConfiguration().update(config_key,config_value);
+	let config_key: string = "python.analysis.diagnosticSeverityOverrides"
+	let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(config_key);
+	config.update("reportMissingModuleSource", "none");
 	let container: Container = await Container.newInstance(context);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.getConfiguration().update("python.linting.pylintEnabled", false);
 
 	let config_key = "python.analysis.diagnosticSeverityOverrides"
-	let current_value = vscode.workspace.getConfiguration()[config_key];
-	current_value["reportMissingModuleSource"] = "none";
-	vscode.workspace.getConfiguration().update(config_key,current_value);
+	let config_value = vscode.workspace.getConfiguration()[config_key];
+	config_value["reportMissingModuleSource"] = "none";
+	vscode.workspace.getConfiguration().update(config_key,config_value);
 	let container: Container = await Container.newInstance(context);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.getConfiguration().update("python.languageServer", "Pylance");
 	vscode.workspace.getConfiguration().update("python.linting.pylintEnabled", false);
 
-	vscode.workspace.getConfiguration().update("python.analysis.diagnosticSeverityOverrides",
-	{
-		"reportMissingModuleSource": "none"
-    }
+	let config_key = "python.analysis.diagnosticSeverityOverrides"
+	let	current_value = vscode.workspace.getConfiguration()[config_key];
+	current_value["reportMissingModuleSource"] = "none"
+	vscode.workspace.getConfiguration().update(config_key,
+		current_value
 	);
 	let container: Container = await Container.newInstance(context);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.getConfiguration().update("python.linting.pylintEnabled", false);
 
 	let config_key = "python.analysis.diagnosticSeverityOverrides"
-	let	current_value = vscode.workspace.getConfiguration()[config_key];
+	let current_value = vscode.workspace.getConfiguration()[config_key];
 	current_value["reportMissingModuleSource"] = "none"
-	vscode.workspace.getConfiguration().update(config_key,
-		current_value
-	);
+	vscode.workspace.getConfiguration().update(config_key,current_value);
 	let container: Container = await Container.newInstance(context);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	let config_key = "python.analysis.diagnosticSeverityOverrides"
 	let current_value = vscode.workspace.getConfiguration()[config_key];
-	current_value["reportMissingModuleSource"] = "none"
+	current_value["reportMissingModuleSource"] = "none";
 	vscode.workspace.getConfiguration().update(config_key,current_value);
 	let container: Container = await Container.newInstance(context);
 }


### PR DESCRIPTION
This should ensure that only the config key we care about is updated, and not every other config that the user has set.

As mentioned in https://github.com/joedevivo/vscode-circuitpython/issues/105

I am NOT a TypeScript developer, but I am a Python developer.  So please review this carefully, as I am not sure how to properly test it, nor do I write TypeScript professionally.
