### PR TITLE
Update to handle non Adafruit supplied libraries

### DIFF
--- a/src/librarymanager/libraryManager.ts
+++ b/src/librarymanager/libraryManager.ts
@@ -23,17 +23,27 @@ class LibraryQP implements vscode.QuickPickItem {
   public constructor(b: Library, p: Library) {
     this.bundleLib = b;
     this.projectLib = p;
-    this.label = b.name;
-
-    if(p === null) {
-      this.op = "install";
-      this.description = `Install version ${b.version}`;
-    } else if(b.version !== p.version) {
-      this.op = "update";
-      this.description = `Update from v${p.version} to v${b.version}`;
+    if(b === undefined) {
+      this.op = "custom";
+      if(p === null) {
+        this.label = "Custom";
+        this.description = "Cannot update";
+      } else {
+        this.label = p.name;
+        this.description = `v${p.version} is a custom library. Not updateable`;
+      }
     } else {
-      this.op = null;
-      this.description = `v${p.version} is installed and up to date.`;
+      this.label = b.name;
+      if(p === null) {
+        this.op = "install";
+        this.description = `Install version ${b.version}`;
+      } else if(b.version !== p.version) {
+        this.op = "update";
+        this.description = `Update from v${p.version} to v${b.version}`;
+      } else {
+        this.op = null;
+        this.description = `v${p.version} is installed and up to date.`;
+      }
     }
   }
 


### PR DESCRIPTION
Currently when you try to list libraries the code takes the filename and tries to look up information about it from the Adafruit libraries. If that file or folder is not found in the list, a fairly hidden error happens and it looks like nothing happened.

This change will use the information from the filename and print out the version and a message. No action is allowed on this library.

In the future it would be interesting to also pull community libraries or allow other library locations to find this upgrade info.

You can see in the image that bluepad32 which is not an Adafruit library show in the list as no updateable.

<img width="1060" alt="image" src="https://github.com/joedevivo/vscode-circuitpython/assets/2744477/2bba7f3d-3f83-4e59-b8f8-2e3bf3ca2506">
