### PR TITLE
Don't overwrite options in `python.analysis.diagnosticSeverityOverrides`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,17 @@
-import * as vscode from 'vscode';
-import { Container } from './container';
+import * as vscode from "vscode";
+import { Container } from "./container";
 
 export async function activate(context: vscode.ExtensionContext) {
-	vscode.workspace.getConfiguration().update("python.languageServer", "Pylance");
-	vscode.workspace.getConfiguration().update("python.linting.pylintEnabled", false);
+  let pythonConfig: vscode.WorkspaceConfiguration =
+    vscode.workspace.getConfiguration("python");
+  pythonConfig.update("languageServer", "Pylance");
+  let pythonAnalysis: Object = pythonConfig.get(
+    "analysis.diagnosticSeverityOverrides"
+  );
+  pythonAnalysis["reportMissingModuleSource"] = "none";
+  pythonConfig.update("analysis.diagnosticSeverityOverrides", pythonAnalysis);
 
-	vscode.workspace.getConfiguration().update("python.analysis.diagnosticSeverityOverrides",
-	{
-		"reportMissingModuleSource": "none"
-    }
-	);
-	let container: Container = await Container.newInstance(context);
+  let container: Container = await Container.newInstance(context);
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ export async function activate(context: vscode.ExtensionContext) {
     "analysis.diagnosticSeverityOverrides"
   );
   pythonAnalysis["reportMissingModuleSource"] = "none";
+  pythonAnalysis["reportShadowedImports"] = "none";
   pythonConfig.update("analysis.diagnosticSeverityOverrides", pythonAnalysis);
 
   let container: Container = await Container.newInstance(context);


### PR DESCRIPTION
This resolves the issue mentioned in #105 and also adds a default setting to ignore `reportShadowedImports` since current versions of the Python extension report errors for `code.py` overwritting the code library from Python.

This is similar to #120  but I believe this is a more expandible method