### PR TITLE
Match newer Pin strings like those on MetroESP32S2

### DIFF
--- a/scripts/build_stubs.py
+++ b/scripts/build_stubs.py
@@ -54,7 +54,7 @@ def normalize_vid_pid(vid_or_pid: str):
 
 
 _PIN_DEF_RE = re.compile(
-    r"\s*{\s*MP_ROM_QSTR\(MP_QSTR_(?P<name>[^\)]*)\)\s*,\s*MP_ROM_PTR\((?P<value>[^\)]*)\).*"
+    r"\s*{\s*(?:MP_ROM_QSTR|MP_OBJ_NEW_QSTR)\(MP_QSTR_(?P<name>[^\)]*)\)\s*,\s*MP_ROM_PTR\((?P<value>[^\)]*)\).*"
 )
 
 


### PR DESCRIPTION
With the old regex the pins on the esp32s2 didn't get added to the stubs, see: https://github.com/adafruit/circuitpython/blob/main/ports/espressif/boards/adafruit_metro_esp32s2/pins.c

This commit fixes that behavior.